### PR TITLE
Mark dependency to JPA as provided

### DIFF
--- a/jpa-matchers/pom.xml
+++ b/jpa-matchers/pom.xml
@@ -34,6 +34,7 @@
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
             <version>1.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I propose to mark the JPA dependency as `provided`.

Problem to mitigate was as follows:
When I added the Maven dependency to _jpa-matchers_ in my POM, my class under test got compile errors.
This was because of the transitive JPA 1.0 dependency of _jpa-matchers_. It conflicted with my JPA 2.0 dependency. The compile error resulted from an signature change in one of `EntityManager`'s methods.

I think part of the problem is, that there's no 2.0 version of `javax.persistence:persistence-api`.
Instead you find JPA 2.0 in e.g. `rg.hibernate.javax:persistence.hibernate-jpa-2.0-api`or `javax:javaee-api:6.0`. That's why Maven doesn't recognise that I already use a higher version of JPA, but instead includes both: JPA 1.0 and 2.0.

That's why I'd propose to mark your dependency as `provided`and rely on the user to provide the actual implementation that fits his needs.
